### PR TITLE
update metdata on all templates

### DIFF
--- a/docs/content/index.html
+++ b/docs/content/index.html
@@ -40,7 +40,7 @@
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="Australian Government Design System" />
 	<meta name="twitter:description" content="Content pages display information clearly" /> 
-	<meta name="twitter:name" content="Australian Government Design System" />
+	<meta name="twitter:site" content="@DTA" />	
 	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
 	
 	<!-- OPENGRAPH -->
@@ -50,7 +50,10 @@
 	<meta property="og:description" content="Content pages display information clearly" />
 	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
 	<meta property="og:url" content="https://designsystem.gov.au" />
-	
+	<meta property="article:published_time" content="2019-05-15" />
+	<meta property="article:tag" content="design system" />
+	<meta property="article:tag" content="templates" />
+
 	<title>Australian Government Design System | Content</title>
 
 	<script type="text/javascript">

--- a/docs/content/index.html
+++ b/docs/content/index.html
@@ -17,8 +17,8 @@
 	<meta name="viewport" content="width=device-width">
 	
 	<!-- AGLS Metadata -->
-	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
+	<link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/" />
 	<meta name="dcterms.title" content="Content page template - Australian Government Design System" />
 	<meta name="dcterms.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
 	<meta name="dcterms.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
@@ -30,26 +30,26 @@
 	<meta name="dcterms.coverage" content="Australia" />
 	<meta name="dcterms.spatial" content="Australia" />
 	<meta name="AGLSTERMS.documentType" content="text" />
-	<meta name="msapplication-TileColor" content="#ffffff">
-	<meta name="theme-color" content="#ffffff">
-	<meta name="robots" content="index, follow">
-	<meta name="author" content="Digital Transformation Agency">
-	<meta name="description" content="Content pages display information clearly">
+	<meta name="msapplication-TileColor" content="#ffffff" />
+	<meta name="theme-color" content="#ffffff" />
+	<meta name="robots" content="index, follow" />
+	<meta name="author" content="Digital Transformation Agency" />
+	<meta name="description" content="Content pages display information clearly" />
 	
 	<!-- TWITTER CARD -->
-	<meta name="twitter:card" content="summary_large_image">
-	<meta name="twitter:title" content="Australian Government Design System">
-	<meta name="twitter:description" content="Content pages display information clearly">
-	<meta name="twitter:name" content="Australian Government Design System">
-	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="Australian Government Design System" />
+	<meta name="twitter:description" content="Content pages display information clearly" /> 
+	<meta name="twitter:name" content="Australian Government Design System" />
+	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
 	
 	<!-- OPENGRAPH -->
-	<meta property="og:type" content="website">
-	<meta property="og:title" content="Content page template - Australian Government Design System">
-	<meta property="og:site_name" content="Australian Government Design System">
-	<meta property="og:description" content="Content pages display information clearly">
-	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
-	<meta property="og:url" content="https://designsystem.gov.au">
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="Content page template - Australian Government Design System" />
+	<meta property="og:site_name" content="Australian Government Design System" />
+	<meta property="og:description" content="Content pages display information clearly" />
+	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
+	<meta property="og:url" content="https://designsystem.gov.au" />
 	
 	<title>Australian Government Design System | Content</title>
 

--- a/docs/content/index.html
+++ b/docs/content/index.html
@@ -17,18 +17,18 @@
 	<meta name="viewport" content="width=device-width">
 	
 	<!-- AGLS Metadata -->
-	<link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/" />
-	<meta name="dcterms.title" content="Content page template - Australian Government Design System" />
+	<link rel="schema.DCTERMS" href="http://purl.org/dc/terms/" />
+	<link rel="schema.AGLSTERMS" href="http://www.agls.gov.au/agls/terms/" />
+	<meta name="DCTERMS.title" content="Content page template - Australian Government Design System" />
 	<meta ... scheme="AGLSTERMS.AglsAgent" content="corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
-	<meta name="dcterms.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
-	<meta name="dcterms.description" content="Content pages display information clearly" />
-`<meta name="DCTERMS.modified" scheme="DCTERMS.ISO8601" content="2010-07-29T12:05:44+10:00" />`
-	<meta name="dcterms.subject" content="design system, templates" />	
-	<meta name="dcterms.language" scheme="dcterms.RFC4646" content="en-AU" />
-	<meta name="dcterms.type" content="Content page template" />
-	<meta name="dcterms.coverage" content="Australia" />
-	<meta name="dcterms.spatial" content="Australia" />
+	<meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="DCTERMS.description" content="Content pages display information clearly" />
+`	<meta name="DCTERMS.modified" scheme="DCTERMS.ISO8601" content="2010-07-29T12:05:44+10:00" />`
+	<meta name="DCTERMS.subject" content="design system, templates" />	
+	<meta name="DCTERMS.language" scheme="DCTERMS.RFC4646" content="en-AU" />
+	<meta name="DCTERMS.type" content="Content page template" />
+	<meta name="DCTERMS.coverage" content="Australia" />
+	<meta name="DCTERMS.spatial" content="Australia" />
 	<meta name="AGLSTERMS.documentType" content="text" />
 	<meta name="msapplication-TileColor" content="#ffffff" />
 	<meta name="theme-color" content="#ffffff" />

--- a/docs/content/index.html
+++ b/docs/content/index.html
@@ -15,6 +15,8 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	
+	<!-- AGLS Metadata -->
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
 	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
 	<meta name="dcterms.title" content="Content page template - Australian Government Design System" />
@@ -33,17 +35,22 @@
 	<meta name="robots" content="index, follow">
 	<meta name="author" content="Digital Transformation Agency">
 	<meta name="description" content="Content pages display information clearly">
+	
+	<!-- TWITTER CARD -->
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:title" content="Australian Government Design System">
 	<meta name="twitter:description" content="Content pages display information clearly">
 	<meta name="twitter:name" content="Australian Government Design System">
 	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	
+	<!-- OPENGRAPH -->
 	<meta property="og:type" content="website">
 	<meta property="og:title" content="Content page template - Australian Government Design System">
 	<meta property="og:site_name" content="Australian Government Design System">
 	<meta property="og:description" content="Content pages display information clearly">
 	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
 	<meta property="og:url" content="https://designsystem.gov.au">
+	
 	<title>Australian Government Design System | Content</title>
 
 	<script type="text/javascript">

--- a/docs/content/index.html
+++ b/docs/content/index.html
@@ -15,7 +15,35 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
-
+	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
+	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
+	<meta name="dcterms.title" content="Content page template - Australian Government Design System" />
+	<meta name="dcterms.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="dcterms.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="dcterms.description" content="Content pages display information clearly" />
+	<meta name="dcterms.modified" content="scheme=dcterms.ISO8601; 2019-08-06T11:36:29+10:00" />
+	<meta name="dcterms.subject" content="design system, templates" />	
+	<meta name="dcterms.language" content="dcterms.RFC4646; en-AU" />
+	<meta name="dcterms.type" content="Content page template" />
+	<meta name="dcterms.coverage" content="Australia" />
+	<meta name="dcterms.spatial" content="Australia" />
+	<meta name="AGLSTERMS.documentType" content="text" />
+	<meta name="msapplication-TileColor" content="#ffffff">
+	<meta name="theme-color" content="#ffffff">
+	<meta name="robots" content="index, follow">
+	<meta name="author" content="Digital Transformation Agency">
+	<meta name="description" content="Content pages display information clearly">
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:title" content="Australian Government Design System">
+	<meta name="twitter:description" content="Content pages display information clearly">
+	<meta name="twitter:name" content="Australian Government Design System">
+	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	<meta property="og:type" content="website">
+	<meta property="og:title" content="Content page template - Australian Government Design System">
+	<meta property="og:site_name" content="Australian Government Design System">
+	<meta property="og:description" content="Content pages display information clearly">
+	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	<meta property="og:url" content="https://designsystem.gov.au">
 	<title>Australian Government Design System | Content</title>
 
 	<script type="text/javascript">

--- a/docs/form/index.html
+++ b/docs/form/index.html
@@ -20,8 +20,8 @@
 	<link rel="schema.DCTERMS" href="http://purl.org/dc/terms/" />
 	<link rel="schema.AGLSTERMS" href="http://www.agls.gov.au/agls/terms/" />
 	<meta name="DCTERMS.title" content="Form page template - Australian Government Design System" />
-	<meta name="DCTERMS.creator" scheme="AGLSTERMS.AglsAgent" content="corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
-	<meta name="DCTERMS.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="DCTERMS.creator" scheme="AGLSTERMS.AglsAgent" content="corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=designsystem@dta.gov.au" />
+	<meta name="DCTERMS.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=designsystem@dta.gov.au" />
 	<meta name="DCTERMS.description" content="Form pages ask users a question and allow them to answer it" />
 	<meta name="DCTERMS.modified" content="scheme=DCTERMS.ISO8601; 2019-08-06T11:36:29+10:00" />
 	<meta name="DCTERMS.subject" content="design system, templates" />	

--- a/docs/form/index.html
+++ b/docs/form/index.html
@@ -40,7 +40,7 @@
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="Australian Government Design System" />
 	<meta name="twitter:description" content="Form pages ask users a question and allow them to answer it" />
-	<meta name="twitter:name" content="Australian Government Design System" />
+	<meta name="twitter:site" content="@DTA" />
 	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
 	
 	<!-- OPENGRAPH -->

--- a/docs/form/index.html
+++ b/docs/form/index.html
@@ -15,7 +15,35 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
-
+	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
+	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
+	<meta name="dcterms.title" content="Form page template - Australian Government Design System" />
+	<meta name="dcterms.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="dcterms.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="dcterms.description" content="Form pages ask users a question and allow them to answer it" />
+	<meta name="dcterms.modified" content="scheme=dcterms.ISO8601; 2019-08-06T11:36:29+10:00" />
+	<meta name="dcterms.subject" content="design system, templates" />	
+	<meta name="dcterms.language" content="dcterms.RFC4646; en-AU" />
+	<meta name="dcterms.type" content="Form template" />
+	<meta name="dcterms.coverage" content="Australia" />
+	<meta name="dcterms.spatial" content="Australia" />
+	<meta name="AGLSTERMS.documentType" content="text" />
+	<meta name="msapplication-TileColor" content="#ffffff">
+	<meta name="theme-color" content="#ffffff">
+	<meta name="robots" content="index, follow">
+	<meta name="author" content="Digital Transformation Agency">
+	<meta name="description" content="Form pages ask users a question and allow them to answer it">
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:title" content="Australian Government Design System">
+	<meta name="twitter:description" content="Form pages ask users a question and allow them to answer it">
+	<meta name="twitter:name" content="Australian Government Design System">
+	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	<meta property="og:type" content="website">
+	<meta property="og:title" content="Form page template - Australian Government Design System">
+	<meta property="og:site_name" content="Australian Government Design System">
+	<meta property="og:description" content="Form pages ask users a question and allow them to answer it">
+	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	<meta property="og:url" content="https://designsystem.gov.au">
 	<title>Australian Government Design System | Form</title>
 
 	<script type="text/javascript">

--- a/docs/form/index.html
+++ b/docs/form/index.html
@@ -15,6 +15,8 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+
+	<!-- AGLS Metadata -->
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
 	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
 	<meta name="dcterms.title" content="Form page template - Australian Government Design System" />
@@ -33,17 +35,22 @@
 	<meta name="robots" content="index, follow">
 	<meta name="author" content="Digital Transformation Agency">
 	<meta name="description" content="Form pages ask users a question and allow them to answer it">
+	
+	<!-- TWITTER CARD -->
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:title" content="Australian Government Design System">
 	<meta name="twitter:description" content="Form pages ask users a question and allow them to answer it">
 	<meta name="twitter:name" content="Australian Government Design System">
 	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	
+	<!-- OPENGRAPH -->
 	<meta property="og:type" content="website">
 	<meta property="og:title" content="Form page template - Australian Government Design System">
 	<meta property="og:site_name" content="Australian Government Design System">
 	<meta property="og:description" content="Form pages ask users a question and allow them to answer it">
 	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
 	<meta property="og:url" content="https://designsystem.gov.au">
+	
 	<title>Australian Government Design System | Form</title>
 
 	<script type="text/javascript">

--- a/docs/form/index.html
+++ b/docs/form/index.html
@@ -17,18 +17,18 @@
 	<meta name="viewport" content="width=device-width">
 
 	<!-- AGLS Metadata -->
-	<link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/" />
-	<meta name="dcterms.title" content="Form page template - Australian Government Design System" />
-	<meta name="dcterms.creator" scheme="AGLSTERMS.AglsAgent" content="corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
-	<meta name="dcterms.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
-	<meta name="dcterms.description" content="Form pages ask users a question and allow them to answer it" />
-	<meta name="dcterms.modified" content="scheme=dcterms.ISO8601; 2019-08-06T11:36:29+10:00" />
-	<meta name="dcterms.subject" content="design system, templates" />	
-	<meta name="dcterms.language" content="dcterms.RFC4646; en-AU" />
-	<meta name="dcterms.type" content="Form template" />
-	<meta name="dcterms.coverage" content="Australia" />
-	<meta name="dcterms.spatial" content="Australia" />
+	<link rel="schema.DCTERMS" href="http://purl.org/dc/terms/" />
+	<link rel="schema.AGLSTERMS" href="http://www.agls.gov.au/agls/terms/" />
+	<meta name="DCTERMS.title" content="Form page template - Australian Government Design System" />
+	<meta name="DCTERMS.creator" scheme="AGLSTERMS.AglsAgent" content="corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="DCTERMS.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="DCTERMS.description" content="Form pages ask users a question and allow them to answer it" />
+	<meta name="DCTERMS.modified" content="scheme=DCTERMS.ISO8601; 2019-08-06T11:36:29+10:00" />
+	<meta name="DCTERMS.subject" content="design system, templates" />	
+	<meta name="DCTERMS.language" content="DCTERMS.RFC4646; en-AU" />
+	<meta name="DCTERMS.type" content="Form template" />
+	<meta name="DCTERMS.coverage" content="Australia" />
+	<meta name="DCTERMS.spatial" content="Australia" />
 	<meta name="AGLSTERMS.documentType" content="text" />
 	<meta name="msapplication-TileColor" content="#ffffff" />
 	<meta name="theme-color" content="#ffffff" />

--- a/docs/form/index.html
+++ b/docs/form/index.html
@@ -17,8 +17,8 @@
 	<meta name="viewport" content="width=device-width">
 
 	<!-- AGLS Metadata -->
-	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
+	<link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/" />
 	<meta name="dcterms.title" content="Form page template - Australian Government Design System" />
 	<meta name="dcterms.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
 	<meta name="dcterms.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
@@ -30,26 +30,27 @@
 	<meta name="dcterms.coverage" content="Australia" />
 	<meta name="dcterms.spatial" content="Australia" />
 	<meta name="AGLSTERMS.documentType" content="text" />
-	<meta name="msapplication-TileColor" content="#ffffff">
-	<meta name="theme-color" content="#ffffff">
-	<meta name="robots" content="index, follow">
-	<meta name="author" content="Digital Transformation Agency">
-	<meta name="description" content="Form pages ask users a question and allow them to answer it">
+	<meta name="msapplication-TileColor" content="#ffffff" />
+	<meta name="theme-color" content="#ffffff" />
+	<meta name="robots" content="index, follow" />
+	<meta name="author" content="Digital Transformation Agency" />
+	<meta name="description" content="Form pages ask users a question and allow them to answer it" />
 	
 	<!-- TWITTER CARD -->
-	<meta name="twitter:card" content="summary_large_image">
-	<meta name="twitter:title" content="Australian Government Design System">
-	<meta name="twitter:description" content="Form pages ask users a question and allow them to answer it">
-	<meta name="twitter:name" content="Australian Government Design System">
-	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="Australian Government Design System" />
+	<meta name="twitter:description" content="Form pages ask users a question and allow them to answer it" />
+	<meta name="twitter:name" content="Australian Government Design System" />
+	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
 	
 	<!-- OPENGRAPH -->
-	<meta property="og:type" content="website">
-	<meta property="og:title" content="Form page template - Australian Government Design System">
-	<meta property="og:site_name" content="Australian Government Design System">
-	<meta property="og:description" content="Form pages ask users a question and allow them to answer it">
-	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
-	<meta property="og:url" content="https://designsystem.gov.au">
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="Form page template - Australian Government Design System" />
+	<meta property="og:site_name" content="Australian Government Design System" />
+	<meta property="og:description" content="Form pages ask users a question and allow them to answer it" />
+	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
+	<meta property="og:image" content="Coat of Arms - Australian Government - Design System logo" />
+	<meta property="og:url" content="https://designsystem.gov.au" />
 	
 	<title>Australian Government Design System | Form</title>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,8 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	
+	<!-- AGLS Metadata -->
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
 	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
 	<meta name="dcterms.title" content="Home page template - Australian Government Design System" />
@@ -34,17 +36,22 @@
 	<meta name="robots" content="index, follow">
 	<meta name="author" content="Digital Transformation Agency">
 	<meta name="description" content="Home page template - Australian Government Design System">
+	
+	<!-- TWITTER CARD -->
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:title" content="Australian Government Design System">
 	<meta name="twitter:description" content="Home page template - Australian Government Design System">
 	<meta name="twitter:name" content="Australian Government Design System">
 	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	
+	<!-- OPENGRAPH -->
 	<meta property="og:type" content="website">
 	<meta property="og:title" content="Home page template - Australian Government Design System">
 	<meta property="og:site_name" content="Australian Government Design System">
 	<meta property="og:description" content="Home pages explain your product or service and help users find what they are looking for">
 	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
 	<meta property="og:url" content="https://designsystem.gov.au">
+	
 	<title>Australian Government Design System | Home</title>
 
 	<script type="text/javascript">

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="Australian Government Design System" />
 	<meta name="twitter:description" content="Home page template - Australian Government Design System" />
-	<meta name="twitter:name" content="Australian Government Design System" />
+	<meta name="twitter:site" content="@DTA" />
 	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
 	<meta name="twitter:image:alt" content="Coat of Arms - Australian Government - Design System logo" />
 	<!-- OPENGRAPH -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,8 +17,8 @@
 	<meta name="viewport" content="width=device-width">
 	
 	<!-- AGLS Metadata -->
-	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
+	<link rel="schema.dcterms" href="http://purl.org/dc/terms/" /> 
+	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/" />
 	<meta name="dcterms.title" content="Home page template - Australian Government Design System" />
 	<meta name="dcterms.identifier" content="https://designsystem.gov.au/templates/home/" />
 	<meta name="dcterms.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
@@ -31,26 +31,27 @@
 	<meta name="dcterms.coverage" content="Australia" />
 	<meta name="dcterms.spatial" content="Australia" />
 	<meta name="AGLSTERMS.documentType" content="text" />
-	<meta name="msapplication-TileColor" content="#ffffff">
-	<meta name="theme-color" content="#ffffff">
-	<meta name="robots" content="index, follow">
-	<meta name="author" content="Digital Transformation Agency">
-	<meta name="description" content="Home page template - Australian Government Design System">
+	<meta name="msapplication-TileColor" content="#ffffff" />
+	<meta name="theme-color" content="#ffffff" />
+	<meta name="robots" content="index, follow" />
+	<meta name="author" content="Digital Transformation Agency" /> 
+	<meta name="description" content="Home page template - Australian Government Design System" />
 	
 	<!-- TWITTER CARD -->
-	<meta name="twitter:card" content="summary_large_image">
-	<meta name="twitter:title" content="Australian Government Design System">
-	<meta name="twitter:description" content="Home page template - Australian Government Design System">
-	<meta name="twitter:name" content="Australian Government Design System">
-	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
-	
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="Australian Government Design System" />
+	<meta name="twitter:description" content="Home page template - Australian Government Design System" />
+	<meta name="twitter:name" content="Australian Government Design System" />
+	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
+	<meta name="twitter:image:alt" content="Coat of Arms - Australian Government - Design System logo" />
 	<!-- OPENGRAPH -->
-	<meta property="og:type" content="website">
-	<meta property="og:title" content="Home page template - Australian Government Design System">
-	<meta property="og:site_name" content="Australian Government Design System">
-	<meta property="og:description" content="Home pages explain your product or service and help users find what they are looking for">
-	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
-	<meta property="og:url" content="https://designsystem.gov.au">
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="Home page template - Australian Government Design System" />
+	<meta property="og:site_name" content="Australian Government Design System" />
+	<meta property="og:description" content="Home pages explain your product or service and help users find what they are looking for" />
+	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg" />
+	<meta property="og:url" content="https://designsystem.gov.au" />
+	<meta name="DCTERMS.identifier" scheme="DCTERMS.URI" content="https://www.designsystem.gov.au/path/to/page/" />
 	
 	<title>Australian Government Design System | Home</title>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,19 +17,19 @@
 	<meta name="viewport" content="width=device-width">
 	
 	<!-- AGLS Metadata -->
-	<link rel="schema.dcterms" href="http://purl.org/dc/terms/" /> 
-	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/" />
-	<meta name="dcterms.title" content="Home page template - Australian Government Design System" />
-	<meta name="dcterms.identifier" content="https://designsystem.gov.au/templates/home/" />
-	<meta name="dcterms.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
-	<meta name="dcterms.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
-	<meta name="dcterms.description" content="Home pages explain your product or service and help users find what they are looking for" />
-	<meta name="dcterms.modified" content="scheme=dcterms.ISO8601; 2019-08-06T11:36:29+10:00" />
-	<meta name="dcterms.subject" content="design system, templates" />		
-	<meta name="dcterms.language" content="dcterms.RFC4646; en-AU" />
-	<meta name="dcterms.type" content="Home page template" />
-	<meta name="dcterms.coverage" content="Australia" />
-	<meta name="dcterms.spatial" content="Australia" />
+	<link rel="schema.DCTERMS" href="http://purl.org/dc/terms/" /> 
+	<link rel="schema.AGLSTERMS" href="http://www.agls.gov.au/agls/terms/" />
+	<meta name="DCTERMS.title" content="Home page template - Australian Government Design System" />
+	<meta name="DCTERMS.identifier" content="https://designsystem.gov.au/templates/home/" />
+	<meta name="DCTERMS.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="DCTERMS.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="DCTERMS.description" content="Home pages explain your product or service and help users find what they are looking for" />
+	<meta name="DCTERMS.modified" content="scheme=DCTERMS.ISO8601; 2019-08-06T11:36:29+10:00" />
+	<meta name="DCTERMS.subject" content="design system, templates" />		
+	<meta name="DCTERMS.language" content="DCTERMS.RFC4646; en-AU" />
+	<meta name="DCTERMS.type" content="Home page template" />
+	<meta name="DCTERMS.coverage" content="Australia" />
+	<meta name="DCTERMS.spatial" content="Australia" />
 	<meta name="AGLSTERMS.documentType" content="text" />
 	<meta name="msapplication-TileColor" content="#ffffff" />
 	<meta name="theme-color" content="#ffffff" />

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,8 +21,8 @@
 	<link rel="schema.AGLSTERMS" href="http://www.agls.gov.au/agls/terms/" />
 	<meta name="DCTERMS.title" content="Home page template - Australian Government Design System" />
 	<meta name="DCTERMS.identifier" content="https://designsystem.gov.au/templates/home/" />
-	<meta name="DCTERMS.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
-	<meta name="DCTERMS.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="DCTERMS.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=designsystem@dta.gov.au" />
+	<meta name="DCTERMS.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=designsystem@dta.gov.au" />
 	<meta name="DCTERMS.description" content="Home pages explain your product or service and help users find what they are looking for" />
 	<meta name="DCTERMS.modified" content="scheme=DCTERMS.ISO8601; 2019-08-06T11:36:29+10:00" />
 	<meta name="DCTERMS.subject" content="design system, templates" />		

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,36 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
-
+	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
+	<link rel="schema.AGLSterms" href="http://www.agls.gov.au/agls/terms/">
+	<meta name="dcterms.title" content="Home page template - Australian Government Design System" />
+	<meta name="dcterms.identifier" content="https://designsystem.gov.au/templates/home/" />
+	<meta name="dcterms.creator" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="dcterms.publisher" content="scheme=AGLSTERMS.AglsAgent; corporateName=Digital Transformation Agency, Australia; address=50 Marcus Clarke St Canberra ACT 2601; contact=+61 427 136 791" />
+	<meta name="dcterms.description" content="Home pages explain your product or service and help users find what they are looking for" />
+	<meta name="dcterms.modified" content="scheme=dcterms.ISO8601; 2019-08-06T11:36:29+10:00" />
+	<meta name="dcterms.subject" content="design system, templates" />		
+	<meta name="dcterms.language" content="dcterms.RFC4646; en-AU" />
+	<meta name="dcterms.type" content="Home page template" />
+	<meta name="dcterms.coverage" content="Australia" />
+	<meta name="dcterms.spatial" content="Australia" />
+	<meta name="AGLSTERMS.documentType" content="text" />
+	<meta name="msapplication-TileColor" content="#ffffff">
+	<meta name="theme-color" content="#ffffff">
+	<meta name="robots" content="index, follow">
+	<meta name="author" content="Digital Transformation Agency">
+	<meta name="description" content="Home page template - Australian Government Design System">
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:title" content="Australian Government Design System">
+	<meta name="twitter:description" content="Home page template - Australian Government Design System">
+	<meta name="twitter:name" content="Australian Government Design System">
+	<meta name="twitter:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	<meta property="og:type" content="website">
+	<meta property="og:title" content="Home page template - Australian Government Design System">
+	<meta property="og:site_name" content="Australian Government Design System">
+	<meta property="og:description" content="Home pages explain your product or service and help users find what they are looking for">
+	<meta property="og:image" content="https://designsystem.gov.au/assets/favicons/designsystem.jpg">
+	<meta property="og:url" content="https://designsystem.gov.au">
 	<title>Australian Government Design System | Home</title>
 
 	<script type="text/javascript">


### PR DESCRIPTION
The metadata in these templates was created using the [AGLS Metadata Standard ](http://www.naa.gov.au/information-management/managing-information-and-records/describing/metadata/AGLS/index.aspx) that has been mandated for use by Australian government agencies.  Also used: [Australian Government Metadata Generator](http://www.agls.gov.au/generator)